### PR TITLE
use rails logger

### DIFF
--- a/lib/timing/railtie.rb
+++ b/lib/timing/railtie.rb
@@ -2,9 +2,9 @@ module Rack
   module Timing
     class TimingRailtie < Rails::Railtie
       initializer "timing_railtie.configure_rails_initialization" do |app|
-        app.middleware.insert 0, Rack::Timing::Start
-        app.middleware.insert 0, Rack::Timing::Reporter
-        app.middleware.use Rack::Timing::End
+        app.middleware.insert 0, Rack::Timing::Start, Rails.logger
+        app.middleware.insert 0, Rack::Timing::Reporter, Rails.logger
+        app.middleware.use Rack::Timing::End, Rails.logger
       end
     end
   end


### PR DESCRIPTION
Rack timing spits out messages to stdout in test mode, I think the Railtie should use Rails.logger which you configure to be Stdout on heroku anyhow.
